### PR TITLE
Don't assume file format for Muzero Model files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,6 @@
-/out/*
-*.tar
-*.tar.examples
-*.prof
-
 __pycache__
 .vscode
 .idea
 .ipynb_checkpoints
 temp
 logs
-out

--- a/MuZero/MuNeuralNet.py
+++ b/MuZero/MuNeuralNet.py
@@ -239,16 +239,18 @@ class MuZeroNeuralNet(ABC):
         dynamics_path = os.path.join(folder, 'd_' + filename)
         predictor_path = os.path.join(folder, 'p_' + filename)
 
-        if not os.path.exists(representation_path):
+        try:
+            self.neural_net.encoder.load_weights(representation_path)
+        except:
             raise FileNotFoundError(f"No MuZero Representation Model in path {representation_path}")
-        if not os.path.exists(dynamics_path):
+        try:
+            self.neural_net.dynamics.load_weights(dynamics_path)
+        except:
             raise FileNotFoundError(f"No MuZero Dynamics Model in path {dynamics_path}")
-        if not os.path.exists(predictor_path):
+        try:
+            self.neural_net.predictor.load_weights(predictor_path)
+        except:
             raise FileNotFoundError(f"No MuZero Predictor Model in path {predictor_path}")
-
-        self.neural_net.encoder.load_weights(representation_path)
-        self.neural_net.dynamics.load_weights(dynamics_path)
-        self.neural_net.predictor.load_weights(predictor_path)
 
         if hasattr(self.neural_net, 'decoder'):
             decoder_path = os.path.join(folder, 'decoder_' + filename)


### PR DESCRIPTION
This is broken in the most recent versions of tensorflow, but EAFP is
a principle which should allow for more robust code. In principle, the
code shouldn't be assuming the file format of the network model save
function.

Closes #6